### PR TITLE
[fix] 修正search API 參數 page 解構錯誤

### DIFF
--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -14,7 +14,7 @@ const categoryMap = {
  */
 router.get("/:category", async (req, res) => {
   const { category } = req.params;
-  const { q = "", rawPage = "1" } = req.query;
+  const { q = "", page: rawPage = "1" } = req.query;
   const page = parseInt(rawPage, 10);
   const table = categoryMap[category];
   const limit = 6;


### PR DESCRIPTION
原始問題 https://github.com/CodecaineWebsite/Codecaine_client/issues/50
此PR是解決後端部分問題

原寫法
 ` const { q = "", rawPage = "1" } = req.query;`
![image](https://github.com/user-attachments/assets/1660220b-9ec1-4e3f-95b5-d6d56ab1c228)
修改為
`const { q = "", page: rawPage = "1" } = req.query;`
![image](https://github.com/user-attachments/assets/dd06e51b-2132-4d3a-a2e7-a429e4df78d8)

因為前端送出的 req.query 格式為 
```
{ q: <關鍵字>, page: <頁數> }
```

所以下面解構 
```
const { rawPage } = req.query
```
因為`req.query`沒有`rawPage`這個 key ，所以 `rawPage` 的值會得到 `undefined`
並且因為 `const { rawPage = "1" } = req.query` 將  `rawPage` 預設值為1
所以後續查詢全部都只會回傳「搜尋結果第一頁」的結果
