### PR TITLE
[feat] Trending頁 API 完成

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ import favoritesRouter from "./src/routes/favorites.js";
 import commentsRouter from "./src/routes/comments.js";
 import followsRouter from "./src/routes/follows.js";
 import searchRouter from "./src/routes/search.js";
+import trendingRouter from "./src/routes/trending.js"
 
 const { Pool } = pg;
 dotenv.config();
@@ -41,6 +42,7 @@ app.use("/api/favorites", favoritesRouter);
 app.use("/api/comments", commentsRouter);
 app.use("/api/follows", followsRouter);
 app.use("/api/search", searchRouter);
+app.use("/api/trending",trendingRouter)
 
 app.listen(PORT, () => {
 	console.log(`Server running at http://localhost:${PORT}`);

--- a/src/routes/trending.js
+++ b/src/routes/trending.js
@@ -10,7 +10,6 @@ router.get("/pens", async (req, res) => {
   const limit = Math.min(parseInt(req.query.limit) || 4, 50);
   const offset = (page - 1) * 4;
 
-  
   const threeDaysAgo = new Date();
   threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
 
@@ -29,13 +28,11 @@ router.get("/pens", async (req, res) => {
     const pens = await db
       .select()
       .from(pensTable)
-      .orderBy(desc(trendingScore))
+      .orderBy(desc(trendingScore), desc(pensTable.created_at))
       .limit(limit)
       .offset(offset);
 
-    const [{ total }] = await db
-      .select({ total: count() })
-      .from(pensTable);
+    const [{ total }] = await db.select({ total: count() }).from(pensTable);
 
     res.json({
       results: pens,

--- a/src/routes/trending.js
+++ b/src/routes/trending.js
@@ -1,0 +1,52 @@
+import { desc, sql, count, gte } from "drizzle-orm";
+import { pensTable } from "../models/schema.js";
+import db from "../config/db.js";
+import express from "express";
+
+const router = express.Router();
+
+router.get("/pens", async (req, res) => {
+  const page = Math.max(parseInt(req.query.page) || 1, 1);
+  const limit = Math.min(parseInt(req.query.limit) || 4, 50);
+  const offset = (page - 1) * 4;
+
+  
+  const threeDaysAgo = new Date();
+  threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+
+  // 熱門加權公式：views * 1 + favorites * 3 + comments * 5 + 最近三天作品加十分
+  const trendingScore = sql`
+    ${pensTable.views_count} * 1 +
+    ${pensTable.favorites_count} * 3 +
+    ${pensTable.comments_count} * 5 +
+    CASE 
+      WHEN ${pensTable.created_at} >= ${threeDaysAgo.toISOString()} THEN 10
+      ELSE 0
+    END
+  `;
+
+  try {
+    const pens = await db
+      .select()
+      .from(pensTable)
+      .orderBy(desc(trendingScore))
+      .limit(limit)
+      .offset(offset);
+
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(pensTable);
+
+    res.json({
+      results: pens,
+      total,
+      totalPages: Math.ceil(total / 4),
+      currentPage: page,
+    });
+  } catch (err) {
+    console.error("取得 Trending 作品失敗", err);
+    res.status(500).json({ error: "伺服器錯誤" });
+  }
+});
+
+export default router;

--- a/src/routes/trending.js
+++ b/src/routes/trending.js
@@ -28,11 +28,19 @@ router.get("/pens", async (req, res) => {
     const pens = await db
       .select()
       .from(pensTable)
+      .where(
+        and(eq(pensTable.is_private, false), eq(pensTable.is_deleted, false))
+      )
       .orderBy(desc(trendingScore), desc(pensTable.created_at))
       .limit(limit)
       .offset(offset);
 
-    const [{ total }] = await db.select({ total: count() }).from(pensTable);
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(pensTable)
+      .where(
+        and(eq(pensTable.is_private, false), eq(pensTable.is_deleted, false))
+      );
 
     res.json({
       results: pens,
@@ -41,8 +49,8 @@ router.get("/pens", async (req, res) => {
       currentPage: page,
     });
   } catch (err) {
-    console.error("取得 Trending 作品失敗", err);
-    res.status(500).json({ error: "伺服器錯誤" });
+    console.error("Failed to fetch trending pens:", err);
+    res.status(500).json({ error: "Internal server error" });
   }
 });
 


### PR DESCRIPTION
close #11

- 新增 `GET /api/trending/pens` API
  - 支援 query 參數 `page`、`limit`
  - 排序依照加權公式：
    - views_count * 1
    - favorites_count * 3
    - comments_count * 5
    - 若為三日內創建，額外加 10 分
    - 若分數相同，則第二排序依據為作品建立時間 (由新到舊)
- 預設每次載入 4 筆，可調整 limit
- 回傳格式包含 total, totalPages, currentPage

## 參數說明

參數名稱 | 類型 | 預設值 | 說明
-- | -- | -- | --
page | number | 1 | 要取得的第幾頁資料（從 1 開始）
limit | number | 4 | 本次要取得幾筆資料（最大 50 筆）第一次載入建議設 8（預載兩頁）


## 測試方式
使用 Postman 或瀏覽器測試：
```
http://localhost:3000/api/trending/pens?page=1&limit=8
```
  - 回傳格式：
    ```json
    {
      "results": [...],      // Trending 筆數陣列
      "total": 99,           // 總筆數
      "totalPages": 25,      // 總頁數（固定以每 4 筆切頁）
      "currentPage": 1
    }
    ```
  ### 前端 Trending.vue 串接指示
- 第一次進入頁面時：
  - 透過 `limit=8` 一次載入第 1 + 2 頁資料（顯示第一頁，預載第二頁）
- 點擊「下一頁」時：
  - 會將預載資料 append 到畫面
  - 並向 API 請求下一頁（ex: 第 3 頁），將 limit 設為 4 並預載到一個 cache 變數
- 卡片資料傳入 `PenCard.vue`，以 2x2 分組顯示（每頁 4 筆）