### PR TITLE
[fix] 後端建立新使用者username名稱不唯一的問題, [feat] 使用者資料表與作品資料表新增欄位與建立 migration 檔案

### DIFF
--- a/src/drizzle/0005_cloudy_union_jack.sql
+++ b/src/drizzle/0005_cloudy_union_jack.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "pens" ADD COLUMN "is_trash" boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "is_deleted" boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_username_unique" UNIQUE("username");

--- a/src/drizzle/meta/0005_snapshot.json
+++ b/src/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,617 @@
+{
+  "id": "e335c6d8-6979-4a43-b6d2-5f2200997af0",
+  "prevId": "7823ebd8-897a-4b19-a0b9-921ca43d7ac8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pen_id": {
+          "name": "pen_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_pen_id_pens_id_fk": {
+          "name": "comments_pen_id_pens_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "pens",
+          "columnsFrom": [
+            "pen_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pen_id": {
+          "name": "pen_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "favorites_pen_id_pens_id_fk": {
+          "name": "favorites_pen_id_pens_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "pens",
+          "columnsFrom": [
+            "pen_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_pen_id_pk": {
+          "name": "favorites_user_id_pen_id_pk",
+          "columns": [
+            "user_id",
+            "pen_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_users_id_fk": {
+          "name": "follows_following_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_follower_id_following_id_pk": {
+          "name": "follows_follower_id_following_id_pk",
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pen_tags": {
+      "name": "pen_tags",
+      "schema": "",
+      "columns": {
+        "pen_id": {
+          "name": "pen_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pen_tags_pen_id_pens_id_fk": {
+          "name": "pen_tags_pen_id_pens_id_fk",
+          "tableFrom": "pen_tags",
+          "tableTo": "pens",
+          "columnsFrom": [
+            "pen_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pen_tags_tag_id_tags_id_fk": {
+          "name": "pen_tags_tag_id_tags_id_fk",
+          "tableFrom": "pen_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pen_tags_pen_id_tag_id_pk": {
+          "name": "pen_tags_pen_id_tag_id_pk",
+          "columns": [
+            "pen_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pens": {
+      "name": "pens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "pens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'untitled'"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_code": {
+          "name": "html_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "css_code": {
+          "name": "css_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "js_code": {
+          "name": "js_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources_css": {
+          "name": "resources_css",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "resources_js": {
+          "name": "resources_js",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "favorites_count": {
+          "name": "favorites_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comments_count": {
+          "name": "comments_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "views_count": {
+          "name": "views_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "view_mode": {
+          "name": "view_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center'"
+        },
+        "is_autosave": {
+          "name": "is_autosave",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_autopreview": {
+          "name": "is_autopreview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_trash": {
+          "name": "is_trash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pens_user_id_users_id_fk": {
+          "name": "pens_user_id_users_id_fk",
+          "tableFrom": "pens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pro": {
+          "name": "is_pro",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_key": {
+          "name": "profile_image_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_last_updated": {
+          "name": "profile_image_last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_link1": {
+          "name": "profile_link1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_link2": {
+          "name": "profile_link2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_link3": {
+          "name": "profile_link3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1749036403746,
       "tag": "0004_lumpy_pandemic",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1749473336266,
+      "tag": "0005_cloudy_union_jack",
+      "breakpoints": true
     }
   ]
 }

--- a/src/middlewares/verifyDB.js
+++ b/src/middlewares/verifyDB.js
@@ -13,23 +13,47 @@ export async function verifyDB(req, res, next) {
 
     // 如果沒有，就創建一筆（首次登入）
     if (!user) {
+      const baseUsername = sanitizeUsername(req.user.name || req.user.email?.split("@")[0] || "user");
+      const username = await generateUniqueUsername(baseUsername);
+
       await db.insert(usersTable).values({
         id: req.userId,
         email: req.user.email,
-        username:
-          req.user.name ||
-          req.user.email?.split("@")[0] ||
-          "FirebaseUser",
-        password_hash: "firebase", // 填預設值，因為用不到
+        username,
         display_name: req.user.name || null,
-        // profile_image: req.firebaseUser.picture || null,  // TODO
         bio: "", // 預設值
       });
     }
 
     next();
   } catch (err) {
-    console.error("使用者資料庫建立錯誤:", err);
-    return res.status(500).json({ error: "使用者資料同步失敗" });
+    console.error("An error occurred while creating the user record:", err);
+    return res.status(500).json({ error: "User data synchronization failed" });
   }
+}
+
+function sanitizeUsername(nameOrEmail) {
+  // 從名稱或 email 前段取值，移除特殊符號與空白
+  return nameOrEmail
+    .toLowerCase()
+    .replace(/\s+/g, '')           // 移除空格
+    .replace(/[^a-z0-9_]/g, '');   // 移除非 a-z、0-9、_
+}
+
+async function generateUniqueUsername(base) {
+  let username = base;
+  let count = 0;
+  const MAX_ATTEMPTS = 100;
+  while (count < MAX_ATTEMPTS) {
+    const exists = await db.select().from(usersTable).where(eq(usersTable.username, username));
+    if (exists.length === 0) break;
+    count++;
+    username = `${base}${count}`;
+  }
+
+  if (count === MAX_ATTEMPTS) {
+  throw new Error("Username generation failed. Try again.");
+}
+  return username;
+
 }

--- a/src/middlewares/verifyFirebase.js
+++ b/src/middlewares/verifyFirebase.js
@@ -1,27 +1,3 @@
-// const admin = require("../config/firebase");
-
-// async function authenticate(req, res, next) {
-// 	const authHeader = req.headers.authorization;
-// 	if (!authHeader || !authHeader.startsWith("Bearer ")) {
-// 		return res.status(401).json({ error: "Missing token" });
-// 	}
-
-// 	const idToken = authHeader.split(" ")[1];
-
-// 	try {
-// 		const decoded = await admin.auth().verifyIdToken(idToken);
-// 		req.user = decoded;
-// 		next();
-// 	} catch (err) {
-// 		console.error("驗證失敗:", err);
-// 		return res.status(401).json({ error: "無效的 token" });
-// 	}
-// }
-
-// module.exports = authenticate;
-
-//////////////////////////////////////////
-// V: 測試
 import admin from "../config/firebase.js";
 
 

--- a/src/models/schema.js
+++ b/src/models/schema.js
@@ -12,10 +12,9 @@ import { sql } from 'drizzle-orm';
 
 // 使用者資料表
 const usersTable = pgTable("users", {
-  // id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
   id: varchar("id", { length: 128 }).primaryKey(),
   email: varchar("email", { length: 255 }).notNull().unique(),
-  username: varchar("username", { length: 50 }).notNull(),
+  username: varchar("username", { length: 50 }).notNull().unique(),
   is_pro: boolean("is_pro").default(false),
   profile_image_url: text("profile_image_url"), // 存網址
   profile_image_key: varchar("profile_image_key",{length:255}),
@@ -26,6 +25,7 @@ const usersTable = pgTable("users", {
   profile_link1: text("profile_link1"),
   profile_link2: text("profile_link2"),
   profile_link3: text("profile_link3"),
+  is_deleted: boolean("is_deleted").default(false),
   created_at: timestamp().defaultNow(),
 });
 
@@ -47,12 +47,12 @@ const pensTable = pgTable("pens", {
   is_autosave: boolean("is_autosave").default(true),
   is_autopreview: boolean("is_autopreview").default(true),
   is_private: boolean("is_private").default(false),
+  is_trash: boolean("is_trash").default(false),
   is_deleted: boolean("is_deleted").default(false),
   created_at: timestamp().defaultNow(),
   updated_at: timestamp().defaultNow(),
   deleted_at: timestamp(),
 });
-// 未來擴充：Preprocessors, external Scripts, npm packages, CSS, Base, Vendor Prefixing, auto save, auto-upating preview, format on save, code indentation, code intent width
 
 // 收藏資料表
 const favoritesTable = pgTable(


### PR DESCRIPTION
### 調整
-  `users.username` 欄位加上 `unique()` 約束避免重複
- 在 `verifyDB` middleware：
  - 新增 `sanitizeUsername()` 與 `generateUniqueUsername()`，確保 username 無空格、不重複
  - 修正可能因 Google/GitHub 登入提供空格或特殊字元導致的路由錯誤
- 錯誤訊息改為英文
-  `users` 資料表新增 `is_deleted` 欄位，用於軟刪除

### 注意
- 若資料庫已有重複 username，請先手動處理或重建資料庫後再執行 migration
- 這次PR已經帶了 migration 檔案，所以不用自己 generate
- 請記得執行 `npm run migrate`更新資料庫 schema

### 測試
- 用 Google 登入新帳號，測試是否產生乾淨、唯一的 username
- 使用者名稱若與既有重複，會自動加上數字後綴（如 `lucy`, `lucy1`, `lucy2`）
- . 登入成功後資料庫應多一筆資料， `is_deleted` 欄位預設 `false`