### PR TITLE
[feat] 新增 Your Work 頁 取得使用者所有tags 的 API 

### DIFF
--- a/src/controllers/yourWorkController.js
+++ b/src/controllers/yourWorkController.js
@@ -118,7 +118,7 @@ export async function searchMyWork(req, res) {
   }
 }
 
-export async function getUserTags(req, res) {
+export async function getMyTags(req, res) {
 
   const userId = req.userId;
 

--- a/src/routes/following.js
+++ b/src/routes/following.js
@@ -8,8 +8,13 @@ const router = express.Router();
 
 router.get("/pens", verifyFirebase, async (req, res) => {
   const userId = req.userId;
-  const page = Math.max(parseInt(req.query.page) || 1, 1);
-  const limit = Math.min(parseInt(req.query.limit) || 4, 50);
+
+  const rawPage = parseInt(req.query.page, 10);
+  const rawLimit = parseInt(req.query.limit, 10);
+
+  const page = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 1;
+  const limit =
+    Number.isInteger(rawLimit) && rawLimit > 0 && rawLimit <= 50 ? rawLimit : 4;
   const offset = (page - 1) * limit;
   const sort = req.query.sort || "recent"; // "recent" | "top"
 

--- a/src/routes/yourWork.js
+++ b/src/routes/yourWork.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { verifyFirebase } from "../middlewares/verifyFirebase.js";
-import { searchYourWork } from "../controllers/yourWorkController.js";
+import { searchMyWork, getUserTags } from "../controllers/yourWorkController.js";
 
 const router = Router();
 
@@ -8,5 +8,12 @@ const router = Router();
  * GET /api/my/pens
  * 搜尋使用者本人作品
  */
-router.get("/pens", verifyFirebase, searchYourWork);
+router.get("/pens", verifyFirebase, searchMyWork);
 export default router;
+
+/**
+ * GET /api/my/tags
+ * 使用者的所有作品中，有使用到的 tag 名稱集合，不重複。
+ */
+router.get("/tags", verifyFirebase, getUserTags);
+

--- a/src/routes/yourWork.js
+++ b/src/routes/yourWork.js
@@ -9,11 +9,13 @@ const router = Router();
  * 搜尋使用者本人作品
  */
 router.get("/pens", verifyFirebase, searchMyWork);
-export default router;
+
 
 /**
  * GET /api/my/tags
  * 使用者的所有作品中，有使用到的 tag 名稱集合，不重複。
  */
 router.get("/tags", verifyFirebase, getMyTags);
+
+export default router;
 

--- a/src/routes/yourWork.js
+++ b/src/routes/yourWork.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { verifyFirebase } from "../middlewares/verifyFirebase.js";
-import { searchMyWork, getUserTags } from "../controllers/yourWorkController.js";
+import { searchMyWork, getMyTags } from "../controllers/yourWorkController.js";
 
 const router = Router();
 
@@ -15,5 +15,5 @@ export default router;
  * GET /api/my/tags
  * 使用者的所有作品中，有使用到的 tag 名稱集合，不重複。
  */
-router.get("/tags", verifyFirebase, getUserTags);
+router.get("/tags", verifyFirebase, getMyTags);
 


### PR DESCRIPTION
路由：`GET /api/my/tags`
功能：回傳使用者的所有作品中，有使用到的 tag 名稱集合，不重複。
此API是為 Your Work 頁的 tag 過濾功能使用

其他：
調整搜尋使用者作品的 API 的 handler 名稱
從 `searchYourWork` 改為 `searchMyWork` 使語意符合目的