### PR TITLE
[feat] Get Work by id 加入回傳is_pro

### DIFF
--- a/src/routes/pens.js
+++ b/src/routes/pens.js
@@ -51,6 +51,7 @@ router.get("/:id", verifySelf, async (req, res) => {
   .select({
     ...pensTable,
     username: usersTable.username,
+    is_pro: usersTable.is_pro,
     display_name: usersTable.display_name,
     profile_image_url: usersTable.profile_image_url,
   })


### PR DESCRIPTION
在GET /api/pens/:id API 加入回傳 is_pro 欄位
配合前端 isPrivate 是isPro 功能的判定 加入此欄位
<img width="500" alt="截圖 2025-06-15 17 45 46" src="https://github.com/user-attachments/assets/04a72139-e731-4084-8242-64a41e467308" />

close #52 