### PR TITLE
[fix] 修正 Following 、 Trending 、Search API 回傳資料欄位與過濾條件 [Refactor] Following 、 Trending 、Search API 程式碼重構

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,12 @@ app.use("/api/following",followingRouter);
 app.use("/api/trending",trendingRouter)
 app.use("/api/my",yourWorkRouter);
 
+// 全域錯誤處理 middleware（放在所有 route 之後）
+app.use((err, req, res, next) => {
+  console.error("Unhandled error:", err);
+  res.status(500).json({ error: "Internal server error" });
+});
+
 app.listen(PORT, () => {
 	console.log(`Server running at http://localhost:${PORT}`);
 });

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ app.use("/api/following",followingRouter);
 app.use("/api/trending",trendingRouter)
 app.use("/api/my",yourWorkRouter);
 
-// 全域錯誤處理 middleware（放在所有 route 之後）
+// 全域錯誤處理
 app.use((err, req, res, next) => {
   console.error("Unhandled error:", err);
   res.status(500).json({ error: "Internal server error" });

--- a/src/middlewares/injectFollowedId.js
+++ b/src/middlewares/injectFollowedId.js
@@ -5,7 +5,6 @@ import { eq } from 'drizzle-orm';
 export async function injectFollowedIds(req, res, next) {
   try {
     const userId = req.userId;
-
     const rows = await db
       .select({ id: followsTable.following_id })
       .from(followsTable)

--- a/src/middlewares/injectFollowedId.js
+++ b/src/middlewares/injectFollowedId.js
@@ -1,0 +1,20 @@
+import { followsTable } from '../models/schema.js';
+import db from '../config/db.js';
+import { eq } from 'drizzle-orm';
+
+export async function injectFollowedIds(req, res, next) {
+  try {
+    const userId = req.userId;
+
+    const rows = await db
+      .select({ id: followsTable.following_id })
+      .from(followsTable)
+      .where(eq(followsTable.follower_id, userId));
+
+    req.followedIds = rows.map((r) => r.id);
+    next();
+  } catch (err) {
+    console.error("Failed to inject followed IDs:", err);
+    next(err);
+  }
+}

--- a/src/middlewares/validatePaginationParams.js
+++ b/src/middlewares/validatePaginationParams.js
@@ -2,16 +2,19 @@ export function validatePaginationParams(req, res, next) {
   const rawPage = parseInt(req.query.page, 10);
   const rawLimit = parseInt(req.query.limit, 10);
 
-  const page = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 1;
-  const limit = Number.isInteger(rawLimit) && rawLimit > 0 && rawLimit <= 50 ? rawLimit : 4;
-  const offset = (page - 1) * limit;
 
-  if (Number.isNaN(rawPage) || Number.isNaN(rawLimit)) {
+  if (!Number.isInteger(rawPage) || rawPage < 1 ) {
     return res.status(400).json({ error: 'Invalid pagination parameters' });
   }
 
+  if (req.query.limit !== undefined && (!Number.isInteger(rawLimit) || rawLimit < 1 || rawLimit > 50)) {
+    return res.status(400).json({ error: "Invalid pagination parameter: limit" });
+  }
+
+  const page = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 1;
+  const limit = Number.isInteger(rawLimit) && rawLimit > 0 && rawLimit <= 50 ? rawLimit : 4;
   // 把結果掛上 req 物件
-  req.pagination = { page, limit, offset };
+  req.pagination = { page: rawPage, limit: rawLimit, offset: 0 };
 
   next();
 }

--- a/src/middlewares/validatePaginationParams.js
+++ b/src/middlewares/validatePaginationParams.js
@@ -1,0 +1,17 @@
+export function validatePaginationParams(req, res, next) {
+  const rawPage = parseInt(req.query.page, 10);
+  const rawLimit = parseInt(req.query.limit, 10);
+
+  const page = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 1;
+  const limit = Number.isInteger(rawLimit) && rawLimit > 0 && rawLimit <= 50 ? rawLimit : 4;
+  const offset = (page - 1) * limit;
+
+  if (Number.isNaN(rawPage) || Number.isNaN(rawLimit)) {
+    return res.status(400).json({ error: 'Invalid pagination parameters' });
+  }
+
+  // 把結果掛上 req 物件
+  req.pagination = { page, limit, offset };
+
+  next();
+}

--- a/src/middlewares/validateSortParam.js
+++ b/src/middlewares/validateSortParam.js
@@ -1,0 +1,11 @@
+export function validateSortParam(req, res, next) {
+  const allowed = ['recent', 'top'];
+  const sort = req.query.sort || 'recent';
+
+  if (!allowed.includes(sort)) {
+    return res.status(400).json({ error: 'Invalid sort parameter' });
+  }
+
+  req.sort = sort;
+  next();
+}

--- a/src/queries/pensSelect.js
+++ b/src/queries/pensSelect.js
@@ -1,0 +1,39 @@
+// queries/pensSelect.js
+import { pensTable, usersTable } from "../models/schema.js";
+import { sql } from "drizzle-orm";
+
+export const selectPensColumns = {
+  id: pensTable.id,
+  title: pensTable.title,
+  description: pensTable.description,
+  html_code: pensTable.html_code,
+  css_code: pensTable.css_code,
+  js_code: pensTable.js_code,
+  resources_css: pensTable.resources_css,
+  resources_js: pensTable.resources_js,
+  is_private: pensTable.is_private,
+  created_at: pensTable.created_at,
+  updated_at: pensTable.updated_at,
+  favorites_count: pensTable.favorites_count,
+  comments_count: pensTable.comments_count,
+  views_count: pensTable.views_count,
+  username: usersTable.username,
+  user_display_name: usersTable.display_name,
+  profile_image: usersTable.profile_image_url,
+  is_pro: usersTable.is_pro,
+};
+
+export function trendingScore() {
+  const threeDaysAgo = new Date();
+  threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+
+  return sql`
+    ${pensTable.views_count} * 1 +
+    ${pensTable.favorites_count} * 3 +
+    ${pensTable.comments_count} * 5 +
+    CASE
+      WHEN ${pensTable.created_at} >= ${threeDaysAgo.toISOString()} THEN 10
+      ELSE 0
+    END
+  `;
+}

--- a/src/routes/following.js
+++ b/src/routes/following.js
@@ -1,5 +1,5 @@
-import { pensTable, followsTable, usersTable } from "../models/schema.js";
-import { and, eq, inArray, desc, sql, count } from "drizzle-orm";
+import { pensTable,} from "../models/schema.js";
+import { and, inArray, count } from "drizzle-orm";
 import { verifyFirebase } from "../middlewares/verifyFirebase.js";
 import { validatePaginationParams } from "../middlewares/validatePaginationParams.js";
 import { validateSortParam } from "../middlewares/validateSortParam.js";
@@ -42,7 +42,7 @@ router.get(
 
       // count 查詢
       const filters = [...publicPensFilters(),inArray(pensTable.user_id, followedIds)];
-      
+
       const [{ total }] = await db
         .select({ total: count() })
         .from(pensTable)

--- a/src/routes/following.js
+++ b/src/routes/following.js
@@ -2,8 +2,11 @@ import { pensTable, followsTable, usersTable } from "../models/schema.js";
 import { and, eq, inArray, desc, sql, count } from "drizzle-orm";
 import { verifyFirebase } from "../middlewares/verifyFirebase.js";
 import { validatePaginationParams } from "../middlewares/validatePaginationParams.js";
+import { validateSortParam } from "../middlewares/validateSortParam.js";
+import { injectFollowedIds } from "../middlewares/injectFollowedId.js";
 import { publicPensFilters } from "../utils/filters.js";
 import { selectPensColumns, trendingScore } from "../queries/pensSelect.js";
+import { paginateResponse } from "../utils/paginationResponse.js";
 import db from "../config/db.js";
 import express from "express";
 
@@ -13,41 +16,29 @@ router.get(
   "/pens",
   verifyFirebase,
   validatePaginationParams,
+  validateSortParam,
+  injectFollowedIds,
   async (req, res) => {
     const userId = req.userId;
     const { page, limit, offset } = req.pagination;
-
-    const sort = req.query.sort || "recent"; // "recent" | "top"
-
+    const { sort, followedIds } = req;
     // 搜尋條件陣列：初始條件： 非刪除 + 非私有 + 非垃圾桶
-    const filters = [
-      ...publicPensFilters(),
-    ];
+    const filters = [...publicPensFilters()];
 
+    if (followedIds.length === 0) {
+      return res.json({
+        results: [],
+        total: 0,
+        totalPages: 0,
+        currentPage: page,
+      });
+    }
+
+    filters.push(inArray(pensTable.user_id, followedIds));
+    const orderBy =
+      sort === "top" ? desc(trendingScore()) : desc(pensTable.created_at);
 
     try {
-      // 取追蹤對象
-      const followedRows = await db
-        .select({ followedId: followsTable.following_id }) // following_id 這個欄位 要改成 followed_id
-        .from(followsTable)
-        .where(eq(followsTable.follower_id, userId));
-
-      const followedIds = followedRows.map((f) => f.followedId);
-
-      if (followedIds.length === 0) {
-        return res.json({
-          results: [],
-          total: 0,
-          totalPages: 0,
-          currentPage: page,
-        });
-      }
-      
-      filters.push(inArray(pensTable.user_id, followedIds));
-      // 排序欄位
-      const orderBy =
-        sort === "top" ? desc(trendingScore()) : desc(pensTable.created_at);
-
       const pens = await db
         .select(selectPensColumns)
         .from(pensTable)
@@ -71,12 +62,8 @@ router.get(
         )
         .where(and(...filters));
 
-      res.json({
-        results: pens,
-        total,
-        totalPages: Math.ceil(total / limit),
-        currentPage: page,
-      });
+      const response = paginateResponse({ data: pens, total, page, limit });
+      res.json(response);
     } catch (err) {
       console.error("Failed to fetch following pens:", err);
       res.status(500).json({ error: "Internal server error" });

--- a/src/routes/following.js
+++ b/src/routes/following.js
@@ -19,7 +19,10 @@ router.get(
   validateSortParam,
   injectFollowedIds,
   async (req, res) => {
-    const { page, limit, offset } = req.pagination;
+    const { page, limit: rawLimit } = req.pagination;
+    const limit = rawLimit ?? 4;
+    const offset = (page - 1) * limit;
+
     const { sort, followedIds } = req;
     
     if (followedIds.length === 0) {

--- a/src/routes/following.js
+++ b/src/routes/following.js
@@ -1,119 +1,88 @@
 import { pensTable, followsTable, usersTable } from "../models/schema.js";
 import { and, eq, inArray, desc, sql, count } from "drizzle-orm";
 import { verifyFirebase } from "../middlewares/verifyFirebase.js";
-import db from "../config/db.js";
 import { validatePaginationParams } from "../middlewares/validatePaginationParams.js";
+import { publicPensFilters } from "../utils/filters.js";
+import { selectPensColumns, trendingScore } from "../queries/pensSelect.js";
+import db from "../config/db.js";
 import express from "express";
 
 const router = express.Router();
 
-router.get("/pens", verifyFirebase, validatePaginationParams, async (req, res) => {
-  const userId = req.userId;
-  const { page, limit, offset } = req.pagination;
+router.get(
+  "/pens",
+  verifyFirebase,
+  validatePaginationParams,
+  async (req, res) => {
+    const userId = req.userId;
+    const { page, limit, offset } = req.pagination;
 
-  const sort = req.query.sort || "recent"; // "recent" | "top"
+    const sort = req.query.sort || "recent"; // "recent" | "top"
 
-  const selectPensColumns = {
-    id: pensTable.id,
-    title: pensTable.title,
-    description: pensTable.description,
-    html_code: pensTable.html_code,
-    css_code: pensTable.css_code,
-    js_code: pensTable.js_code,
-    resources_css: pensTable.resources_css,
-    resources_js: pensTable.resources_js,
-    is_private: pensTable.is_private,
-    created_at: pensTable.created_at,
-    updated_at: pensTable.updated_at,
-    favorites_count: pensTable.favorites_count,
-    comments_count: pensTable.comments_count,
-    views_count: pensTable.views_count,
-    username: usersTable.username,
-    user_display_name: usersTable.display_name,
-    profile_image: usersTable.profile_image_url,
-    is_pro: usersTable.is_pro,
-  }; // 要查詢的欄位
+    // 搜尋條件陣列：初始條件： 非刪除 + 非私有 + 非垃圾桶
+    const filters = [
+      ...publicPensFilters(),
+    ];
 
-  // 搜尋條件陣列：初始條件： 非刪除 + 非私有 + 非垃圾桶
-  const filters = [
-    eq(pensTable.is_private, false),
-    eq(pensTable.is_deleted, false),
-    eq(pensTable.is_trash, false),
-  ];
 
-  const threeDaysAgo = new Date();
-  threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+    try {
+      // 取追蹤對象
+      const followedRows = await db
+        .select({ followedId: followsTable.following_id }) // following_id 這個欄位 要改成 followed_id
+        .from(followsTable)
+        .where(eq(followsTable.follower_id, userId));
 
-  const trendingScore = sql`
-  ${pensTable.views_count} * 1 +
-  ${pensTable.favorites_count} * 3 +
-  ${pensTable.comments_count} * 5 +
-  CASE 
-    WHEN ${pensTable.created_at} >= ${threeDaysAgo.toISOString()} THEN 10
-    ELSE 0
-  END
-`;
+      const followedIds = followedRows.map((f) => f.followedId);
 
-  try {
-    // 取追蹤對象
-    const followedRows = await db
-      .select({ followedId: followsTable.following_id }) // following_id 這個欄位 要改成 followed_id
-      .from(followsTable)
-      .where(eq(followsTable.follower_id, userId));
+      if (followedIds.length === 0) {
+        return res.json({
+          results: [],
+          total: 0,
+          totalPages: 0,
+          currentPage: page,
+        });
+      }
+      
+      filters.push(inArray(pensTable.user_id, followedIds));
+      // 排序欄位
+      const orderBy =
+        sort === "top" ? desc(trendingScore()) : desc(pensTable.created_at);
 
-    const followedIds = followedRows.map((f) => f.followedId);
+      const pens = await db
+        .select(selectPensColumns)
+        .from(pensTable)
+        .leftJoin(usersTable, eq(pensTable.user_id, usersTable.id))
+        .leftJoin(
+          followsTable,
+          eq(pensTable.user_id, followsTable.following_id)
+        )
+        .where(and(inArray(pensTable.user_id, followedIds), ...filters))
+        .orderBy(orderBy)
+        .limit(limit)
+        .offset(offset);
 
-    if (followedIds.length === 0) {
-      return res.json({
-        results: [],
-        total: 0,
-        totalPages: 0,
+      const [{ total }] = await db
+        .select({ total: count() })
+        .from(pensTable)
+        .leftJoin(usersTable, eq(pensTable.user_id, usersTable.id))
+        .leftJoin(
+          followsTable,
+          eq(pensTable.user_id, followsTable.following_id)
+        )
+        .where(and(...filters));
+
+      res.json({
+        results: pens,
+        total,
+        totalPages: Math.ceil(total / limit),
         currentPage: page,
       });
+    } catch (err) {
+      console.error("Failed to fetch following pens:", err);
+      res.status(500).json({ error: "Internal server error" });
     }
-
-    // 排序欄位
-    const orderBy =
-      sort === "top" ? desc(trendingScore) : desc(pensTable.created_at);
-
-    const pens = await db
-      .select(selectPensColumns)
-      .from(pensTable)
-      .leftJoin(usersTable, eq(pensTable.user_id, usersTable.id))
-      .leftJoin(followsTable, eq(pensTable.user_id, followsTable.following_id))
-      .where(
-        and(
-          inArray(pensTable.user_id, followedIds),
-          ...filters
-        )
-      )
-      .orderBy(orderBy)
-      .limit(limit)
-      .offset(offset);
-
-    const [{ total }] = await db
-      .select({ total: count() })
-      .from(pensTable)
-      .leftJoin(usersTable, eq(pensTable.user_id, usersTable.id))
-      .leftJoin(followsTable, eq(pensTable.user_id, followsTable.following_id))
-      .where(
-        and(
-          inArray(pensTable.user_id, followedIds),
-          ...filters
-        )
-      );
-
-    res.json({
-      results: pens,
-      total,
-      totalPages: Math.ceil(total / limit),
-      currentPage: page,
-    });
-  } catch (err) {
-    console.error("Failed to fetch following pens:", err);
-    res.status(500).json({ error: "Internal server error" });
   }
-});
+);
 
 export default router;
 

--- a/src/routes/following.js
+++ b/src/routes/following.js
@@ -19,12 +19,9 @@ router.get(
   validateSortParam,
   injectFollowedIds,
   async (req, res) => {
-    const userId = req.userId;
     const { page, limit, offset } = req.pagination;
     const { sort, followedIds } = req;
-    // 搜尋條件陣列：初始條件： 非刪除 + 非私有 + 非垃圾桶
     
-
     if (followedIds.length === 0) {
       return res.json({
         results: [],
@@ -42,7 +39,6 @@ router.get(
 
       // count 查詢
       const filters = [...publicPensFilters(),inArray(pensTable.user_id, followedIds)];
-
       const [{ total }] = await db
         .select({ total: count() })
         .from(pensTable)
@@ -58,5 +54,3 @@ router.get(
 );
 
 export default router;
-
-//TODO: following_id 這個欄位 要改成 followed_id

--- a/src/routes/trending.js
+++ b/src/routes/trending.js
@@ -9,7 +9,9 @@ import express from "express";
 const router = express.Router();
 
 router.get("/pens", validatePaginationParams, async (req, res) => {
-  const { page, limit, offset } = req.pagination;
+  const { page, limit: rawLimit } = req.pagination;
+  const limit = rawLimit ?? 4;
+  const offset = (page - 1) * limit;
   const filters = publicPensFilters();
 
   try {

--- a/src/routes/trending.js
+++ b/src/routes/trending.js
@@ -1,6 +1,8 @@
-import { desc, sql, count, and, eq } from "drizzle-orm";
+import { desc, count, and, eq } from "drizzle-orm";
 import { pensTable, usersTable } from "../models/schema.js";
 import { validatePaginationParams } from "../middlewares/validatePaginationParams.js";
+import { publicPensFilters } from "../utils/filters.js";
+import { selectPensColumns, trendingScore } from "../queries/pensSelect.js";
 import db from "../config/db.js";
 import express from "express";
 
@@ -8,47 +10,9 @@ const router = express.Router();
 
 router.get("/pens", validatePaginationParams, async (req, res) => {
   const { page, limit, offset } = req.pagination;
-  
-  const selectPensColumns = {
-    id: pensTable.id,
-    title: pensTable.title,
-    description: pensTable.description,
-    html_code: pensTable.html_code,
-    css_code: pensTable.css_code,
-    js_code: pensTable.js_code,
-    resources_css: pensTable.resources_css,
-    resources_js: pensTable.resources_js,
-    is_private: pensTable.is_private,
-    created_at: pensTable.created_at,
-    updated_at: pensTable.updated_at,
-    favorites_count: pensTable.favorites_count,
-    comments_count: pensTable.comments_count,
-    views_count: pensTable.views_count,
-    username: usersTable.username,
-    user_display_name: usersTable.display_name,
-    profile_image: usersTable.profile_image_url,
-    is_pro: usersTable.is_pro,
-  }; // 要查詢的欄位
 
   // 搜尋條件陣列：初始條件： 非刪除 + 非私有 + 非垃圾桶
-  const filters = [
-    eq(pensTable.is_private, false),
-    eq(pensTable.is_deleted, false),
-    eq(pensTable.is_trash, false),
-  ];
-
-  // 熱門加權公式：views * 1 + favorites * 3 + comments * 5 + 最近三天作品加十分
-  const threeDaysAgo = new Date();
-  threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
-  const trendingScore = sql`
-    ${pensTable.views_count} * 1 +
-    ${pensTable.favorites_count} * 3 +
-    ${pensTable.comments_count} * 5 +
-    CASE 
-      WHEN ${pensTable.created_at} >= ${threeDaysAgo.toISOString()} THEN 10
-      ELSE 0
-    END
-  `;
+  const filters = publicPensFilters();
 
   try {
     const pens = await db
@@ -56,7 +20,7 @@ router.get("/pens", validatePaginationParams, async (req, res) => {
       .from(pensTable)
       .leftJoin(usersTable, eq(pensTable.user_id, usersTable.id))
       .where(and(...filters))
-      .orderBy(desc(trendingScore), desc(pensTable.created_at))
+      .orderBy(desc(trendingScore()), desc(pensTable.created_at))
       .limit(limit)
       .offset(offset);
 
@@ -64,13 +28,19 @@ router.get("/pens", validatePaginationParams, async (req, res) => {
       .select({ total: count() })
       .from(pensTable)
       .where(and(...filters));
+    // 如果沒有筆記，直接返回空結果
+    if (total === 0) {
+      return res.json({
+        results: [],
+        total: 0,
+        totalPages: 0,
+        currentPage: page,
+      });
+    }
 
-    res.json({
-      results: pens,
-      total,
-      totalPages: Math.ceil(total / 4),
-      currentPage: page,
-    });
+    const response = paginateResponse({ data: pens, total, page, limit });
+
+    res.json(response);
   } catch (err) {
     console.error("Failed to fetch trending pens:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/src/routes/trending.js
+++ b/src/routes/trending.js
@@ -3,6 +3,7 @@ import { pensTable, usersTable } from "../models/schema.js";
 import { validatePaginationParams } from "../middlewares/validatePaginationParams.js";
 import { publicPensFilters } from "../utils/filters.js";
 import { selectPensColumns, trendingScore } from "../queries/pensSelect.js";
+import { paginateResponse } from "../utils/paginationResponse.js";
 import db from "../config/db.js";
 import express from "express";
 

--- a/src/routes/trending.js
+++ b/src/routes/trending.js
@@ -10,8 +10,6 @@ const router = express.Router();
 
 router.get("/pens", validatePaginationParams, async (req, res) => {
   const { page, limit, offset } = req.pagination;
-
-  // 搜尋條件陣列：初始條件： 非刪除 + 非私有 + 非垃圾桶
   const filters = publicPensFilters();
 
   try {
@@ -28,7 +26,7 @@ router.get("/pens", validatePaginationParams, async (req, res) => {
       .select({ total: count() })
       .from(pensTable)
       .where(and(...filters));
-    // 如果沒有筆記，直接返回空結果
+
     if (total === 0) {
       return res.json({
         results: [],

--- a/src/routes/trending.js
+++ b/src/routes/trending.js
@@ -1,19 +1,14 @@
 import { desc, sql, count, and, eq } from "drizzle-orm";
 import { pensTable, usersTable } from "../models/schema.js";
+import { validatePaginationParams } from "../middlewares/validatePaginationParams.js";
 import db from "../config/db.js";
 import express from "express";
 
 const router = express.Router();
 
-router.get("/pens", async (req, res) => {
-  const rawPage = parseInt(req.query.page, 10);
-  const rawLimit = parseInt(req.query.limit, 10);
-
-  const page = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 1;
-  const limit =
-    Number.isInteger(rawLimit) && rawLimit > 0 && rawLimit <= 50 ? rawLimit : 4;
-  const offset = (page - 1) * limit;
-
+router.get("/pens", validatePaginationParams, async (req, res) => {
+  const { page, limit, offset } = req.pagination;
+  
   const selectPensColumns = {
     id: pensTable.id,
     title: pensTable.title,

--- a/src/services/pensService.js
+++ b/src/services/pensService.js
@@ -9,10 +9,6 @@ export async function listFollowedPens({ followedIds, limit, offset, sort }) {
     return [];
   }
 
-  const filters = [
-    ...publicPensFilters(), // 非私有、非刪除、非垃圾桶
-    inArray(pensTable.user_id, followedIds),
-  ];
   const orderBy = sort === 'top' ? desc(trendingScore()) : desc(pensTable.created_at);
 
   return db

--- a/src/services/pensService.js
+++ b/src/services/pensService.js
@@ -1,0 +1,26 @@
+import  db from '../config/db.js';
+import { and, desc, eq, sql, inArray } from 'drizzle-orm';
+import { pensTable, usersTable } from '../models/schema.js';
+import { publicPensFilters } from "../utils/filters.js";
+import { selectPensColumns, trendingScore } from '../queries/pensSelect.js';
+
+export async function listFollowedPens({ followedIds, limit, offset, sort }) {
+  if (!followedIds || followedIds.length === 0) {
+    return [];
+  }
+
+  const filters = [
+    ...publicPensFilters(), // 非私有、非刪除、非垃圾桶
+    inArray(pensTable.user_id, followedIds),
+  ];
+  const orderBy = sort === 'top' ? desc(trendingScore()) : desc(pensTable.created_at);
+
+  return db
+    .select(selectPensColumns)
+    .from(pensTable)
+    .leftJoin(usersTable, eq(pensTable.user_id, usersTable.id))
+    .where(and(inArray(pensTable.user_id, followedIds), ...publicPensFilters()))
+    .orderBy(orderBy)
+    .limit(limit)
+    .offset(offset);
+}

--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -1,0 +1,10 @@
+import { eq } from 'drizzle-orm';
+import { pensTable } from '../models/schema.js';
+
+export function publicPensFilters() {
+  return [
+    eq(pensTable.is_private, false),
+    eq(pensTable.is_deleted, false),
+    eq(pensTable.is_trash, false),
+  ];
+}

--- a/src/utils/paginationResponse.js
+++ b/src/utils/paginationResponse.js
@@ -1,0 +1,8 @@
+export function paginateResponse({ data, total, page, limit }) {
+  return {
+    results: data,
+    total,
+    totalPages: Math.ceil(total / limit),
+    currentPage: page,
+  };
+}

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -1,0 +1,17 @@
+import { or, like, sql } from "drizzle-orm";
+import { usersTable } from "../models/schema.js";
+
+/**
+ * 把關鍵字陣列轉成 LIKE 條件陣列
+ * @param {string[]} keywords
+ * @param {Table} table - drizzle-orm 定義的資料表
+ */
+export function buildKeywordConditions(keywords, table) {
+  return keywords.map((kw) =>
+    or(
+      like(sql`LOWER(${table.title})`, `%${kw}%`),
+      like(sql`LOWER(${table.description})`, `%${kw}%`),
+      like(sql`LOWER(${usersTable.username})`, `%${kw}%`)
+    )
+  );
+}


### PR DESCRIPTION
close #44
close #47
clsoe #60

### 總結

新增回傳資料欄位，增加 username等資料
重構了 /trending/pens 、 /following/pens 和 /search API 三支 API 的邏輯，將重複邏輯模組化、條件組合抽離、統一資料欄位與熱門排序公式統一管理

### 變更

#### 新增回傳資料欄位與過濾條件調整
回傳資料欄位新增
```javascript
    {
    username: usersTable.username,
    user_display_name: usersTable.display_name,
    profile_image: usersTable.profile_image_url,
    is_pro: usersTable.is_pro,
    }
```
過濾條件調整，過濾私人、垃圾桶、已刪除作品
```javascritpt
[
    eq(pensTable.is_private, false),
    eq(pensTable.is_deleted, false),
    eq(pensTable.is_trash, false),
  ]
```

#### Trending (GET /api/trending/pens)

- 抽出 `selectPensColumns `與 `trendingScore()` 到` queries/pensSelect.js`
- 抽出公開作品查詢條件` publicPensFilters()` 至` utils/filters.js`
- 使用 `paginateResponse()` 統一回傳格式
- 移除不必要的 `leftJoin` 操作於` count() `查詢中
- 移除硬編碼的 `Math.ceil(total / 4)`，改用 limit

#### Following (GET /api/following/pens)
- 由 service `listFollowedPens()` 處理查詢條件與欄位
- 移除 router 內 `filters `組裝邏輯，交由 service` listFollowedPens()` 處理
- 若` followedIds.length === 0`，直接回傳空結果避免多餘查詢
- 保留 count 查詢於 router，並使用相同 `filters` 組合
- 使用 `paginateResponse() `統一回傳格式

#### Search API (GET /search/:category)

- 使用 `categoryMap` 定義查詢表格、欄位、額外條件與預設筆數
- 支援關鍵字搜尋（可多關鍵字），條件透過 `buildKeywordConditions()` 建立
- 使用` validatePaginationParams` middleware 統一分頁處理
- 支援自動 fallback limit，並依 meta.defaultLimit 彈性控制
- 使用 `paginateResponse()` 包裝回傳資料

#### 新增檔案

- `middlewares/validatePaginationParams.js`
- `middlewares/validateSortParam.js`
- `middlewares/injectFollowedIds.js`
- `utils/filters.js`（公開作品條件）
- `utils/search.js` （建立多關鍵字搜尋條件的工具）
- `utils/paginationResponse.js`（統一分頁格式）
- `queries/pensSelect.js`（欄位選擇與熱門排序公式）
- `services/pensService.js`（封裝 `listFollowedPens()` 查詢邏輯）


- 可重用邏輯抽離，減少重複
- 路由處理聚焦在參數與回傳
- 準備做單元測試

#### 其他

-  count 查詢也可抽進 service

