### PR TITLE
[fix] 修正非第三方使用者沒有預設display_name的問題，新增使用者預設頭像網址

### DIFF
--- a/src/middlewares/verifyDB.js
+++ b/src/middlewares/verifyDB.js
@@ -20,8 +20,9 @@ export async function verifyDB(req, res, next) {
         id: req.userId,
         email: req.user.email,
         username,
-        display_name: req.user.name || null,
-        bio: "", // 預設值
+        profile_image_url : "https://codecaine-client-staging.zeabur.app/default-avatar.png",
+        display_name: req.user.name || username ||null,
+        bio: "",
       });
     }
 


### PR DESCRIPTION
close #79
### 調整
1. 當使用者第一次登入同步資料庫時，新增的使用者資料增加預設 display_name，以解決作品卡無法正常顯示作者暱稱的問題
2. 新增使用者預設頭像網址，使進入設定頁面時頭像不為空