### PR TITLE
[refactor]重構 Stripe webhook 處理邏輯，新增訂閱更新與取消功能

### DIFF
--- a/src/controllers/stripeController.js
+++ b/src/controllers/stripeController.js
@@ -54,8 +54,8 @@ export const handleStripeWebhook = async (req, res, endpointSecret) => {
           canceled_at: subscription.cancel_at
             ? new Date(subscription.cancel_at * 1000)
             : null,
-          current_period_end: subscription.current_period_end
-            ? new Date(subscription.current_period_end * 1000)
+          current_period_end: subscription.items?.data[0]?.current_period_end
+            ? new Date(subscription.items?.data[0]?.current_period_end * 1000)
             : null,
           updated_at: new Date(),
         },
@@ -236,6 +236,7 @@ export const cancelSubscription = async (req, res) => {
       .set({
         cancel_at_period_end: true,
         updated_at: new Date(),
+        current_period_end: new Date(canceled.current_period_end * 1000),
       })
       .where(eq(subscriptionsTable.id, subscription.id));
 

--- a/src/controllers/stripeController.js
+++ b/src/controllers/stripeController.js
@@ -187,7 +187,7 @@ export const createSubscriptionSession = async (req, res) => {
       },
       success_url: `${
         process.env.BASE_URL || "http://localhost:5173"
-      }/${encodeURIComponent(username)}/caines/showcase?subscribed=true`,
+      }/${encodeURIComponent(username)}/doses/showcase?subscribed=true`,
       cancel_url: `${
         process.env.BASE_URL || "http://localhost:5173"
       }/settings/billing?subscribed=false`,


### PR DESCRIPTION
修復stripe webhook的問題
原先路由設計 監聽了錯誤的事件
會導致 資料庫紀錄的status付款狀態為imcomplete
此一行為產生來自付款狀態進行中的status為imcomplete而導致
應該監聽的事件為checkout.session.completed
