### PR TITLE
[fix] 將使用者預設頭像設為上傳至AWS的預設頭像

### DIFF
--- a/src/middlewares/verifyDB.js
+++ b/src/middlewares/verifyDB.js
@@ -20,8 +20,8 @@ export async function verifyDB(req, res, next) {
         id: req.userId,
         email: req.user.email,
         username,
-        profile_image_url : "https://codecaine-client-staging.zeabur.app/default-avatar.png",
-        display_name: req.user.name || username ||null,
+        profile_image_url : "https://image-uploader-codecaine.s3.ap-southeast-2.amazonaws.com/default-avatar.png",
+        display_name: req.user.name || username || "user",
         bio: "",
       });
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/40259692-509a-4374-8ff5-1ed678bfcb41)
將使用者預設頭像修改為AWS S3版本