### PR TITLE
[fix]修復註冊無法進入profile的bug

### DIFF
--- a/src/middlewares/verifyDB.js
+++ b/src/middlewares/verifyDB.js
@@ -13,14 +13,16 @@ export async function verifyDB(req, res, next) {
 
     // 如果沒有，就創建一筆（首次登入）
     if (!user) {
-      const baseUsername = sanitizeUsername(req.user.name || req.user.email?.split("@")[0] || "user");
+      const baseUsername = sanitizeUsername(
+        req.user.name || req.user.email?.split("@")[0] || "user"
+      );
       const username = await generateUniqueUsername(baseUsername);
-
       await db.insert(usersTable).values({
         id: req.userId,
         email: req.user.email,
         username,
-        profile_image_url : "https://image-uploader-codecaine.s3.ap-southeast-2.amazonaws.com/default-avatar.png",
+        profile_image_url:
+          "https://image-uploader-codecaine.s3.ap-southeast-2.amazonaws.com/default-avatar.png",
         display_name: req.user.name || username || "user",
         bio: "",
       });
@@ -37,8 +39,8 @@ function sanitizeUsername(nameOrEmail) {
   // 從名稱或 email 前段取值，移除特殊符號與空白
   return nameOrEmail
     .toLowerCase()
-    .replace(/\s+/g, '')           // 移除空格
-    .replace(/[^a-z0-9_]/g, '');   // 移除非 a-z、0-9、_
+    .replace(/\s+/g, "") // 移除空格
+    .replace(/[^\u4e00-\u9fa5_a-z0-9]/gi, ""); // 保留中文、英數、_
 }
 
 async function generateUniqueUsername(base) {
@@ -46,15 +48,17 @@ async function generateUniqueUsername(base) {
   let count = 0;
   const MAX_ATTEMPTS = 100;
   while (count < MAX_ATTEMPTS) {
-    const exists = await db.select().from(usersTable).where(eq(usersTable.username, username));
+    const exists = await db
+      .select()
+      .from(usersTable)
+      .where(eq(usersTable.username, username));
     if (exists.length === 0) break;
     count++;
     username = `${base}${count}`;
   }
 
   if (count === MAX_ATTEMPTS) {
-  throw new Error("Username generation failed. Try again.");
-}
+    throw new Error("Username generation failed. Try again.");
+  }
   return username;
-
 }


### PR DESCRIPTION
`.replace(/[^\u4e00-\u9fa5_a-z0-9]/gi, ""); // 保留中文、英數、_`
原本的寫法會把中文也過濾掉
```
 const baseUsername = sanitizeUsername(
        req.user.name || req.user.email?.split("@")[0] || "user"
      );
```
這一串是有抓到req.user.name的
`.replace(/[^a-z0-9_]/g, ''); // 移除非 a-z、0-9、_`
在這邊轉換以後 中文不會被保留 
三方登入的name只要是中文進入個人檔案就會因為沒有username產生bug
