### PR TITLE
[fix] 刪除 penTable description 字數限制

### DIFF
--- a/src/models/schema.js
+++ b/src/models/schema.js
@@ -38,7 +38,7 @@ const pensTable = pgTable("pens", {
   id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
   user_id: varchar("user_id", { length: 128 }).references(() => usersTable.id),
   title: varchar("title", { length: 100 }).default("untitled"),
-  description: varchar("description", { length: 500 }),
+  description: varchar("description"),
   html_code: text("html_code"),
   css_code: text("css_code"),
   js_code: text("js_code"),


### PR DESCRIPTION
刪除 penTable description 500個字的字數限制